### PR TITLE
Feature/static tables seeddata

### DIFF
--- a/Munilytics.Server/Domain/Entities/DimGender.cs
+++ b/Munilytics.Server/Domain/Entities/DimGender.cs
@@ -5,6 +5,7 @@ namespace Munilytics.Server.Domain.Entities
 {
     public class DimGender
     {
+        public int Id { get; set; }
         public GenderCode Code { get; set; }
         public string GenderName { get; set; } = string.Empty;
         public int SortOrder { get; set; }

--- a/Munilytics.Server/Domain/Entities/DimTime.cs
+++ b/Munilytics.Server/Domain/Entities/DimTime.cs
@@ -3,7 +3,7 @@
     public class DimTime
     {
         public int Id { get; set; } 
-        public DateOnly Year { get; set; } 
+        public int Year { get; set; } 
         public int Decade { get; set; } 
         public string MandatePeriod { get; set; } = string.Empty;
         public bool IsElectionYear { get; set; } 

--- a/Munilytics.Server/Infrastructure/Persistence/Configurations/DimGenderConfiguration.cs
+++ b/Munilytics.Server/Infrastructure/Persistence/Configurations/DimGenderConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Munilytics.Server.Domain.Entities;
+using Munilytics.Server.Domain.Enums;
 
 namespace Munilytics.Server.Infrastructure.Persistence.Configurations
 {
@@ -8,8 +9,9 @@ namespace Munilytics.Server.Infrastructure.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<DimGender> builder)
         {
-            builder.HasKey(dg => dg.Code);
+            builder.HasKey(dg => dg.Id);
 
+            builder.Property(dg => dg.Code).HasMaxLength(1).HasConversion<string>().IsRequired(); // Makes certain that the db saves it as a char and not the index of the enum, ergo T instead of 0, for readability.
             builder.Property(dg => dg.GenderName).IsRequired();
             builder.Property(dg => dg.SortOrder).IsRequired();
 
@@ -17,6 +19,12 @@ namespace Munilytics.Server.Infrastructure.Persistence.Configurations
                 .HasMany(dg => dg.FactKpiMeasurements)
                 .WithOne(fkm => fkm.DimGender)
                 .HasForeignKey(fkm => fkm.DimGenderId);
+
+            builder.HasData(
+                new DimGender { Id = 1, Code = GenderCode.T, GenderName = "Total", SortOrder = 1 },
+                new DimGender { Id = 2, Code = GenderCode.F, GenderName = "Female", SortOrder = 2 },
+                new DimGender { Id = 3, Code = GenderCode.M, GenderName = "Male", SortOrder = 3 }
+            );
         }
     }
 }

--- a/Munilytics.Server/Infrastructure/Persistence/Configurations/DimTimeConfiguration.cs
+++ b/Munilytics.Server/Infrastructure/Persistence/Configurations/DimTimeConfiguration.cs
@@ -20,6 +20,36 @@ namespace Munilytics.Server.Infrastructure.Persistence.Configurations
                 .HasMany(dt => dt.FactKpiMeasurements)
                 .WithOne(fkm => fkm.DimTime)
                 .HasForeignKey(fkm => fkm.DimTimeId);
+
+            builder.HasData(GenerateTimeData());
+
+
+        }
+
+        private IEnumerable<DimTime> GenerateTimeData()
+        {
+            var times = new List<DimTime>();
+            int idCounter = 0;
+
+            for (int i = 1994; i <= DateTime.Now.Year; i++)
+            {
+                idCounter++;
+
+                int offset = (i - 1994) % 4;
+                int mandateStart = i - offset;
+
+                times.Add(new DimTime
+                {
+                    Id = idCounter,
+                    Year = i,
+                    Decade = (i / 10) * 10,
+                    IsElectionYear = (i - 1994) % 4 == 0,
+                    RelativeYear = i - DateTime.Now.Year,
+                    MandatePeriod = $"{mandateStart}-{mandateStart + 3}"
+                });
+            }
+
+            return times;
         }
     }
 }


### PR DESCRIPTION
# Solving #36 
- This merge adds seed data for the two static dimension tables in Munilytics, with data for all three gender categories and the years 1994 up and including 2026.

## Other cleanups
- Changed dim gender's primary key after more research into data warehouses
- Changed year property from DateOnly into Integer

