### PR TITLE
resolving missing swagger middleware

### DIFF
--- a/Munilytics.Server/Program.cs
+++ b/Munilytics.Server/Program.cs
@@ -21,7 +21,6 @@ builder.AddServiceDefaults();
 builder.Services.AddProblemDetails();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
 
 // Get connectionstring from Aspire
 var connectionString = builder.Configuration.GetConnectionString("MunilyticsDb");
@@ -73,11 +72,6 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 app.UseExceptionHandler();
 
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
-
 app.MapDefaultEndpoints();
 
 app.UseFileServer();
@@ -86,5 +80,10 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.UseFastEndpoints();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwaggerGen();
+}
 
 app.Run();


### PR DESCRIPTION
\# Fixing missing middleware

Found issue where you could not enter swagger from localhosts due to a missing middleware in Program.cs. Added it, and removed a redundant openApi middleware, since this project is using fastendpoints.



* These changes has been tested and proven to work by @me
