### PR TITLE
Feature/issue 32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,4 @@ FodyWeavers.xsd
 
 ./cube/*
 frontend/package-lock.json
+/cube/.cubestore/data

--- a/Munilytics.Server/Domain/Entities/FactKpiMeasurement.cs
+++ b/Munilytics.Server/Domain/Entities/FactKpiMeasurement.cs
@@ -4,7 +4,7 @@
     {
         public int Id { get; set; }
         public decimal Value { get; set; }
-        public bool IsDefinite { get; set; }
+        public string Status { get; set; } = string.Empty;
         public int Count { get; set; }
         public DateTime ImportDate { get; set; }
         public DateTime LatestUpdate { get; set; }

--- a/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
+++ b/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
@@ -1,16 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Wolverine;
 using FastEndpoints;
+using Microsoft.EntityFrameworkCore;
+using Munilytics.Server.Domain.Entities;
 using Munilytics.Server.Features.Admin.SyncFactData.DTOs;
-using Wolverine.Attributes;
+using Munilytics.Server.Infrastructure.Kolada.DTOs;
 using Munilytics.Server.Infrastructure.Persistence;
 using Munilytics.Server.Interfaces;
-using Munilytics.Server.Infrastructure.Kolada;
-using Munilytics.Server.Models.DTOs;
-using Munilytics.Server.Infrastructure.Kolada.DTOs;
+using Wolverine;
+using Wolverine.Attributes;
 
 namespace Munilytics.Server.Features.Admin.SyncFactData
 {
@@ -26,7 +22,7 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
 
         public override void Configure()
         {
-            Get("/admin/fact");
+            Post("/admin/sync/facts");
             AllowAnonymous();
         }
 
@@ -56,7 +52,39 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
                 throw new ApplicationException("Could not find any facts from Kolada. Something must be wrong");
             }
 
-            var existingFacts = db.Fact_KpiMeasurements.ToList();
+            //For MVP i will only check Municipality ID. For real production we would need to compare all rows
+            var existingFacts = await db.Fact_KpiMeasurements.ToDictionaryAsync(f => f.DimMunicipalityId, f => f, ct);
+
+            foreach (var dto in newFacts)
+            {
+                if (existingFacts.TryGetValue(dto.MunicipalityId, out var existingIdentity))
+                {
+                    existingIdentity.Value = dto.Value;
+                    existingIdentity.Count = dto.Count;
+                    existingIdentity.LatestUpdate = DateTime.Now;
+
+                    /* Values from JSON that we don't have in our facttable yet:
+                     * Gender (This is it's own dimension but dont know how to get a Gender string into entire object)
+                     * Status
+                     * IsDeleted
+                     * Period
+                    */
+                }
+                else
+                {
+                    var newEntity = new FactKpiMeasurement
+                    {
+                        Value = dto.Value,
+                        Count = dto.Count,
+                        ImportDate = DateTime.Now,
+                        LatestUpdate = DateTime.Now,
+                        DimMunicipalityId = dto.MunicipalityId,
+                        DimKpiId = dto.KpiId,
+                    };
+
+                    db.Fact_KpiMeasurements.Add(newEntity);
+                }
+            }
 
             return new SyncFactDataResponse("Syncing of facts complete", true);
         }

--- a/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
+++ b/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
 using Munilytics.Server.Domain.Entities;
+using Munilytics.Server.Domain.Enums;
 using Munilytics.Server.Features.Admin.SyncFactData.DTOs;
 using Munilytics.Server.Infrastructure.Kolada.DTOs;
 using Munilytics.Server.Infrastructure.Persistence;
@@ -54,21 +55,26 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
 
             //For MVP i will only check Municipality ID. For real production we would need to compare all rows
             var existingFacts = await db.Fact_KpiMeasurements.ToDictionaryAsync(f => f.DimMunicipalityId, f => f, ct);
+            var gendersByCode = await db.Dim_Gender.ToDictionaryAsync(g => g.Code, g => g.Id, ct);
 
             foreach (var dto in newFacts)
             {
+                if (!Enum.TryParse<GenderCode>(dto.Gender, true, out var genderCode) ||
+                    !gendersByCode.TryGetValue(genderCode, out var genderId))
+                {
+                    throw new ApplicationException($"Unknown gender code '{dto.Gender}'.");
+                }
+
                 if (existingFacts.TryGetValue(dto.MunicipalityId, out var existingIdentity))
                 {
                     existingIdentity.Value = dto.Value;
                     existingIdentity.Count = dto.Count;
                     existingIdentity.LatestUpdate = DateTime.Now;
-
-                    /* Values from JSON that we don't have in our facttable yet:
-                     * Gender (This is it's own dimension but dont know how to get a Gender string into entire object)
-                     * Status
-                     * IsDeleted
-                     * Period
-                    */
+                    existingIdentity.DimTime = new DimTime
+                    {
+                        Year = dto.Year
+                    };
+                    existingIdentity.DimGenderId = genderId;
                 }
                 else
                 {
@@ -76,10 +82,15 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
                     {
                         Value = dto.Value,
                         Count = dto.Count,
-                        ImportDate = DateTime.Now,
+                        ImportDate = DateTime.Today,
                         LatestUpdate = DateTime.Now,
                         DimMunicipalityId = dto.MunicipalityId,
                         DimKpiId = dto.KpiId,
+                        DimTime = new DimTime
+                        {
+                            Year = dto.Year
+                        },
+                        DimGenderId = genderId
                     };
 
                     db.Fact_KpiMeasurements.Add(newEntity);

--- a/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
+++ b/Munilytics.Server/Features/Admin/SyncFactData/SyncFactData.cs
@@ -75,6 +75,7 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
                         Year = dto.Year
                     };
                     existingIdentity.DimGenderId = genderId;
+                    existingIdentity.Status = dto.Status;
                 }
                 else
                 {
@@ -90,7 +91,8 @@ namespace Munilytics.Server.Features.Admin.SyncFactData
                         {
                             Year = dto.Year
                         },
-                        DimGenderId = genderId
+                        DimGenderId = genderId,
+                        Status = dto.Status
                     };
 
                     db.Fact_KpiMeasurements.Add(newEntity);

--- a/Munilytics.Server/Infrastructure/Kolada/DTOs/KoladaFactDto.cs
+++ b/Munilytics.Server/Infrastructure/Kolada/DTOs/KoladaFactDto.cs
@@ -8,12 +8,12 @@ namespace Munilytics.Server.Infrastructure.Kolada.DTOs
 {
     public record KoladaFactDto(
         [property: JsonPropertyName("gender")] string Gender,
-        [property: JsonPropertyName("count")] string Count,
+        [property: JsonPropertyName("count")] int Count,
         [property: JsonPropertyName("status")] string Status,
         [property: JsonPropertyName("value")] decimal Value,
         [property: JsonPropertyName("isdeleted")] bool Isdeleted,
-        [property: JsonPropertyName("kpi")] string KpiId,
+        [property: JsonPropertyName("kpi")] int KpiId,
         [property: JsonPropertyName("period")] string Period,
-        [property: JsonPropertyName("municipality")] string MunicipalityId
+        [property: JsonPropertyName("municipality")] int MunicipalityId
     );
 }

--- a/Munilytics.Server/Infrastructure/Kolada/DTOs/KoladaFactDto.cs
+++ b/Munilytics.Server/Infrastructure/Kolada/DTOs/KoladaFactDto.cs
@@ -13,7 +13,7 @@ namespace Munilytics.Server.Infrastructure.Kolada.DTOs
         [property: JsonPropertyName("value")] decimal Value,
         [property: JsonPropertyName("isdeleted")] bool Isdeleted,
         [property: JsonPropertyName("kpi")] int KpiId,
-        [property: JsonPropertyName("period")] string Period,
+        [property: JsonPropertyName("period")] int Year,
         [property: JsonPropertyName("municipality")] int MunicipalityId
     );
 }

--- a/Munilytics.Server/Infrastructure/Persistence/Configurations/FactKpiMeasurementConfiguration.cs
+++ b/Munilytics.Server/Infrastructure/Persistence/Configurations/FactKpiMeasurementConfiguration.cs
@@ -11,7 +11,7 @@ namespace Munilytics.Server.Infrastructure.Persistence.Configurations
             builder.HasKey(kpm => kpm.Id);
 
             builder.Property(fkm => fkm.Value).IsRequired();
-            builder.Property(fkm => fkm.IsDefinite).IsRequired();
+            builder.Property(fkm => fkm.Status).IsRequired();
             builder.Property(fkm => fkm.Count).IsRequired();
             builder.Property(fkm => fkm.ImportDate).IsRequired();
             builder.Property(fkm => fkm.LatestUpdate).IsRequired();


### PR DESCRIPTION
### Implements:
1. Endpoint and method to add new FactKpiMeasurement tables to our db, aswell as checking if the same data already exists and updating if necessary.

### Includes changes:
1. Changes to KoladaFactDto so that we can work with the values in our ETL. 
2. FactKpiMeasurement Entity, changed IsDefinite bool to be named "Status" instead, which will now be a string
